### PR TITLE
Use loop form in orderedMin4 to enable inlining

### DIFF
--- a/ordered.go
+++ b/ordered.go
@@ -282,28 +282,20 @@ func orderedMin3[T cmp.Ordered](items []T, l int, min bool, i, j, k int) int {
 
 // orderedMin4 finds the extremum among up to 4 consecutive elements
 // starting at index i.
+//
+// Uses a loop instead of unrolled comparisons so the compiler's
+// inlining cost stays under the budget (the unrolled form costs 130;
+// budget is 80).
 func orderedMin4[T cmp.Ordered](items []T, l int, min bool, i int) int {
 	q := i
-	i++
-	if i >= l {
-		return q
+	end := i + 4
+	if end > l {
+		end = l
 	}
-	if orderedLess(items, min, i, q) {
-		q = i
-	}
-	i++
-	if i >= l {
-		return q
-	}
-	if orderedLess(items, min, i, q) {
-		q = i
-	}
-	i++
-	if i >= l {
-		return q
-	}
-	if orderedLess(items, min, i, q) {
-		q = i
+	for i++; i < end; i++ {
+		if orderedLess(items, min, i, q) {
+			q = i
+		}
 	}
 	return q
 }


### PR DESCRIPTION
## Summary

- Rewrites `orderedMin4` from unrolled-with-early-exits to a loop, reducing the Go compiler's inlining cost from 130 to 63 (budget: 80)
- This allows `orderedMin4` to be inlined into `orderedBubbledown`'s hot loop, eliminating function call overhead on every iteration
- No algorithm or semantic changes — same min-max heap behavior

## Benchmarks

Isolated change, Apple M4 Max, `go test -bench BenchmarkOrdered -benchmem -count=5 -benchtime=2s`:

```
                  │   master     │     orderedMin4 loop                │
                  │    sec/op    │    sec/op     vs base               │
OrderedPop-16       286.0n         236.5n       -17.31% (p=0.008)
OrderedPopMax-16    283.9n         234.9n       -17.26% (p=0.008)
OrderedPushPop-16   290.4n         246.5n       -15.12% (p=0.008)
OrderedPush-16      11.83n         11.76n            ~ (p=0.381)
```

Two other candidate optimizations (`isMinHeap` simplification, bounds-check-elimination hint in `orderedBubbledown`) were benchmarked in isolation and showed slight regressions, so they were dropped.

## Test plan

- [x] `go test -race -count=1 ./...` passes
- [x] Existing unit, randomized (1000 iterations), and fuzz tests all exercise `orderedMin4` through Pop/PopMax/Remove/Fix paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)