### PR TITLE
Use Codecov token for coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
 
-      - name: Upload coverage
+      - name: Upload coverage reports to Codecov
         if: matrix.go-version == '1.23'
         uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Switch to explicit `CODECOV_TOKEN` secret for the codecov-action v5 upload step
- Remove hardcoded `files:` parameter — the action auto-detects `coverage.out`

## Test plan
- [ ] Verify `CODECOV_TOKEN` is set in repo secrets
- [ ] Confirm coverage badge updates after merge